### PR TITLE
Update release dumping

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/BaseDataDumpsProcess.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/BaseDataDumpsProcess.pm
@@ -35,18 +35,6 @@ use base ('Bio::EnsEMBL::Hive::Process');
 
 use Bio::EnsEMBL::Registry;
 
-sub data_dir {
-  my ($self,$species) = @_;
-  my $data_dump_dir = $self->param('pipeline_dir');
-  my $species_division = $self->param('species_division');
-  # If division is defined append the pipeline_dir
-  if ($species_division)
-  {
-    $data_dump_dir = $data_dump_dir."/".$species_division;
-  }
-  return $data_dump_dir;
-}
-
 sub get_all_species {
     my $self = shift;
     my $registry = 'Bio::EnsEMBL::Registry';

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/CleanUp.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/CleanUp.pm
@@ -33,21 +33,23 @@ use strict;
 
 use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsProcess');
 
+sub fetch_input {
+  my $self = shift;
+}
+
 sub run {
   my $self = shift;
+  my $data_dump_dir = $self->param('pipeline_dir');
   my $tmp_dir = $self->param('tmp_dir');
   my $file_type = $self->param('file_type');
 
   my $species = $self->param('species');
   my $mode = $self->param('mode');
-  my $data_dump_dir = $self->data_dir($species);
-
+  
   if ($mode eq 'post_gvf_dump') {
     my $working_dir = "$data_dump_dir/$file_type/$species";
-    opendir(my $dh, $working_dir) or die $!;
-    my @dir_content = readdir($dh);
-    closedir($dh);
-    foreach my $file (@dir_content) {
+    opendir(DIR, $working_dir) or die $!;
+    while (my $file = readdir(DIR))	{
       if ($file =~ m/gvf$/) {
         `gzip $working_dir/$file`;
       } 
@@ -55,15 +57,14 @@ sub run {
         `mv $working_dir/$file $tmp_dir`;
       }
     }				
+    closedir(DIR);
   }
 
   if ($mode eq 'post_join_dumps') {
     foreach my $file_type (qw/vcf gvf/) {
       my $working_dir = "$data_dump_dir/$file_type/$species";
-      opendir(my $dh, $working_dir) or die $!;
-      my @dir_content = readdir($dh);
-      closedir($dh);
-      foreach my $file (@dir_content) {
+      opendir(DIR, $working_dir) or die $!;
+      while (my $file = readdir(DIR))	{
         if ($file =~ m/generic/) {
           my $file_name = $file;
           $file_name =~ s/_generic//;
@@ -76,8 +77,13 @@ sub run {
           `gzip $working_dir/$file`;
         }
       }				
+      closedir(DIR);
     }
   }
+}
+
+sub write_output {
+  my $self = shift;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FileUtils.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FileUtils.pm
@@ -33,19 +33,23 @@ use strict;
 
 use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsProcess');
 
+sub fetch_input {
+  my $self = shift;
+}
+
 sub run {
   my $self = shift;
   my $mode = $self->param('mode');
-  my $tmp_dir = $self->param('tmp_dir');
-  my $species = $self->param('species');
-  my $data_dump_dir = $self->data_dir($species);
-
-  $self->post_gvf_dump_cleanup($data_dump_dir,$tmp_dir,$species) if ($mode eq 'post_gvf_dump_cleanup');
-  $self->post_gvf2vcf_cleanup($data_dump_dir,$tmp_dir,$species) if ($mode eq 'post_gvf2vcf_cleanup');
+  $self->post_gvf_dump_cleanup if ($mode eq 'post_gvf_dump_cleanup');
+  $self->post_gvf2vcf_cleanup if ($mode eq 'post_gvf2vcf_cleanup');
 }
 
 sub post_gvf_dump_cleanup {
-  my ($self,$data_dump_dir,$tmp_dir,$species) = @_;
+  my $self = shift;
+  my $data_dump_dir = $self->param('pipeline_dir');
+  my $tmp_dir = $self->param('tmp_dir');
+  my $species = $self->param('species');
+
   system("gzip $data_dump_dir/gvf/$species/*.gvf");
   system("cat $data_dump_dir/gvf/$species/Validate_* > $tmp_dir/GVF_Validate_$species");
   system("rm $data_dump_dir/gvf/$species/Validate_*");
@@ -54,7 +58,10 @@ sub post_gvf_dump_cleanup {
 }
 
 sub post_gvf2vcf_cleanup {
-  my ($self,$data_dump_dir,$tmp_dir,$species) = @_;
+  my $self = shift;
+  my $data_dump_dir = $self->param('pipeline_dir');
+  my $tmp_dir = $self->param('tmp_dir');
+  my $species = $self->param('species');
   system("cat $data_dump_dir/vcf/$species/Validate_* > $tmp_dir/VCF_Validate_$species");
   system("rm $data_dump_dir/vcf/$species/Validate_*");
   system("cat $data_dump_dir/vcf/$species/*.{err,out} > $tmp_dir/VCF_$species");
@@ -65,8 +72,6 @@ sub post_gvf2vcf_cleanup {
 
 sub write_output {
   my $self = shift;
-  $self->dataflow_output_id({}, 2);
-  $self->dataflow_output_id({}, 1);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FinishDumpPopulation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FinishDumpPopulation.pm
@@ -54,10 +54,8 @@ sub clean_up_vcf_files {
   my $human_vcf_dir = "$pipeline_dir/vcf/Homo_sapiens/";
   die "$human_vcf_dir is not a directory" unless (-d $human_vcf_dir);
 
-  opendir(my $dh, "$pipeline_dir/vcf/Homo_sapiens") or die $!;
-  my @dir_content = readdir($dh);
-  closedir($dh);
-  foreach my $file (@dir_content) {
+  opendir(DIR, "$pipeline_dir/vcf/Homo_sapiens") or die $!;
+  while (my $file = readdir(DIR)) {
     if ($file =~ m/\.vcf$/) {
       my $vcf_file = "$pipeline_dir/vcf/Homo_sapiens/$file";
       $self->run_cmd("vcf-sort < $vcf_file | bgzip > $vcf_file.gz");

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitJoinDump.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitJoinDump.pm
@@ -38,21 +38,18 @@ use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsPro
 
 sub run {
   my $self = shift;
+  my $pipeline_dir = $self->param('pipeline_dir');
   my $species      = $self->param('species');
-  my $pipeline_dir = $self->data_dir($species);
-
 
   my @input = ();
  
   foreach my $file_type (qw/gvf vcf/) {
 
     my $dir = "$pipeline_dir/$file_type/$species/";
+    opendir(DIR, $dir) or die $!;
     my $files = {};
 
-    opendir(my $dh, $dir) or die $!;
-    my @dir_content = readdir($dh);
-    closedir($dh);
-    foreach my $file (@dir_content) {
+    while (my $file = readdir(DIR)) {
       next if ($file =~ m/^\./);
       if ($file =~ m/\.$file_type\.gz/) {
         my $file_name = $file;
@@ -86,9 +83,9 @@ sub run {
 sub write_output {
   my $self = shift;
   if (scalar @{$self->param('input')} > 0) {
-    $self->dataflow_output_id($self->param('input'), 2);
+    $self->dataflow_output_id($self->param('input'), 1);
   } else {
-    $self->dataflow_output_id([{mode => 'no_join'}], 2);
+    $self->dataflow_output_id([{mode => 'no_join'}], 1);
   }
   return;
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitSubmitJob.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitSubmitJob.pm
@@ -44,13 +44,10 @@ sub fetch_input {
   my $species   = $self->param('species');
   my $config    = $self->param('config');
   my $release   = $self->param('release');
+  my $output_dir = $self->param('pipeline_dir');
   my $job_type  = $self->param('job_type'); # parse or dump
-
   $debug = $self->param('debug');
 
-  my $output_dir = $self->data_dir($species);
-
-  my $fh;
 
   $global_vf_count_in_species = $self->param('global_vf_count_in_species') || $global_vf_count_in_species;
   $max_vf_load = $self->param('max_vf_load') || $max_vf_load; # group slices together until the vf count exceeds max_vf_load
@@ -129,7 +126,7 @@ sub fetch_input {
 #          print $debug_fh "COVERED_SE"$key, ' ', $covered_seq_regions->{$key}, "\n";
 #        }   
 #      }
-      my $vf_distributions = $self->get_vf_distributions($covered_seq_regions,$species,$output_dir);
+      my $vf_distributions = $self->get_vf_distributions($covered_seq_regions);
 #      if ($debug) {
 #        foreach my $distribution (@$vf_distributions) {
 #          foreach my $key (keys %$distribution) {
@@ -138,12 +135,12 @@ sub fetch_input {
 #          print $fh "\n";
 #        }
 #      }
-      $input = $self->get_input_gvf_dumps($script_args,$species,$output_dir,$vf_distributions);
+      $input = $self->get_input_gvf_dumps($script_args, $vf_distributions);
     } else {
-      $input = $self->get_input_gvf_dumps($script_args,$species,$output_dir);
+      $input = $self->get_input_gvf_dumps($script_args);
     }
   } elsif ($job_type eq 'parse') {
-    $input = $self->get_input_gvf2vcf($script_args,$species,$output_dir);
+    $input = $self->get_input_gvf2vcf($script_args); 
   } else {
     die "Job type must be parse or dump. $job_type is not recognised.";
   }
@@ -155,22 +152,26 @@ sub fetch_input {
 }
 
 sub get_input_gvf2vcf {
-  my ($self,$script_args,$species,$output_dir) = @_;
+  my $self = shift;
+  my $script_args = shift;
+
+
+
 
   my $file_type       = 'vcf';
   my $script_dir      = $self->param('script_dir');
   my $script          = '/misc/release/gvf2vcf.pl';
-  my $connection_args = '--registry ' . $self->param('registry');
+  my $output_dir      = $self->param('pipeline_dir');
+  my $connection_args = '--registry ' . $self->param('registry_file');
   my $species = $self->param('species');
   my @input = ();
 
   # don't forget to parse Populations and Individuals
 
   my $gvf_dir = "$output_dir/gvf/$species/";
-  opendir(my $dh, $gvf_dir) or die $!;
-  my @dir_content = readdir($dh);
-  closedir($dh);
-  foreach my $gvf_file (@dir_content) {
+  opendir(DIR, $gvf_dir) or die $!;
+
+  while (my $gvf_file = readdir(DIR)) {
     next if ($gvf_file =~ m/^\./);
     next if ($gvf_file =~ m/failed/); # don't parse gvf files storing failed variants
     if ($gvf_file =~ m/\.gvf\.gz$/) {
@@ -194,11 +195,14 @@ sub get_input_gvf2vcf {
       push @input, $params;
     }
   }
+  closedir(DIR);
   return \@input;
 }
 
 sub get_script_arg {
-  my ($self, $file_name, $script_args) = @_;
+  my $self = shift;
+  my $file_name = shift;
+  my $script_args = shift;
   my $return_script_arg = '';
   while (my ($script_arg, $dump_type) = each %$script_args) {
     $self->warning("get_script_arg $script_arg $dump_type");
@@ -215,13 +219,16 @@ sub get_script_arg {
 }
 
 sub get_input_gvf_dumps {
-  my ($self,$script_args,$species,$output_dir,$vf_distributions) = @_;
+  my $self = shift;
+  my $script_args = shift;
+  my $vf_distributions = shift; 
 
   my $file_type       = 'gvf';
   my $script_dir      = $self->param('script_dir');
   my $script          = '/export/release/dump_gvf.pl';
-  my $connection_args = '--registry ' . $self->param('registry');
-
+  my $output_dir      = $self->param('pipeline_dir');
+  my $connection_args = '--registry ' . $self->param('registry_file');
+  my $species = $self->param('species');
   my @input = ();
   my $run_in_debug_mode = $debug ? '--debug' : '';
   my $default_params = {
@@ -285,7 +292,10 @@ sub get_input_gvf_dumps {
 }
 
 sub get_vf_distributions {
-  my ($self, $covered_seq_regions_counts,$species,$output_dir) = @_;
+  my $self = shift;
+  my $covered_seq_regions_counts = shift;
+  my $output_dir = $self->param('pipeline_dir');
+  my $species = $self->param('species');
   my @vf_loads = ();
 
   my $current_vf_load = 0;
@@ -302,13 +312,15 @@ sub get_vf_distributions {
       }
       push @vf_loads, @split_slices;
     } else {
+     
+ 
       if (($current_vf_load + $vf_count) > $max_vf_load) {
         push @seq_region_ids, $seq_region_id;
         push @vf_loads, $self->get_seq_regions(\@seq_region_ids, "$output_dir/gvf/$species/"); 
         if ($debug) {
           my $tmp_load = $current_vf_load + $vf_count; 
           print $debug_fh "JOIN_SLICES\t", join(',', @seq_region_ids), "\t$tmp_load\n";  
-        }
+        } 
         @seq_region_ids = ();
         $current_vf_load = 0;
       } else {
@@ -319,10 +331,8 @@ sub get_vf_distributions {
   }
 
   if (scalar @seq_region_ids > 0) {
-    push @vf_loads, $self->get_seq_regions(\@seq_region_ids, "$output_dir/gvf/$species/");
-    if ($debug) {
-      print $debug_fh "JOIN_SLICES\t", join(',', @seq_region_ids), "\t$current_vf_load\n";
-    }
+    push @vf_loads, $self->get_seq_regions(\@seq_region_ids, "$output_dir/gvf/$species/"); 
+    print $debug_fh "JOIN_SLICES\t", join(',', @seq_region_ids), "\t$current_vf_load\n";  
 
   }
 
@@ -330,7 +340,9 @@ sub get_vf_distributions {
 }
 
 sub get_seq_regions {
-  my ($self, $seq_region_ids, $species_dir) = @_;
+  my $self = shift;
+  my $seq_region_ids = shift;
+  my $species_dir = shift;
   my $seq_regions = $seq_region_ids->[0] . '_' . $seq_region_ids->[-1];
   my $seq_region_ids_file = "$species_dir/$seq_regions.txt";
   my $fh = FileHandle->new($seq_region_ids_file, 'w');
@@ -425,7 +437,7 @@ sub get_covered_seq_regions {
 sub write_output { 
   my $self = shift;
   my $dump_input_parameters = $self->param('input_for_submit_job');
-  $self->dataflow_output_id($dump_input_parameters, 2);
+  $self->dataflow_output_id($dump_input_parameters, 1);
   return;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitValidation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitValidation.pm
@@ -32,14 +32,15 @@ package Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::InitValidation;
 use strict;
 use warnings;
 
+use FileHandle;
+
 use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsProcess');
 
 sub run {
   my $self = shift;
+  my $pipeline_dir = $self->param('pipeline_dir');
   my $file_type    = $self->param('file_type');
   my $species      = $self->param('species');
-  my $pipeline_dir = $self->data_dir($species);
-
   my $working_dir = "$pipeline_dir/$file_type/$species/";
   my $files = get_files($working_dir);
   my @input = ();
@@ -54,22 +55,21 @@ sub run {
 
 sub get_files {
   my $working_dir = shift;
+  opendir(DIR, $working_dir) or die $!;
   my $files = {};
-  opendir(my $dh, $working_dir) or die $!;
-  my @dir_content = readdir($dh);
-  closedir($dh);
-  foreach my $file (@dir_content) {
+  while (my $file = readdir(DIR)) {
     if ($file =~ m/\.gvf$/) {
       $file =~ s/\.gvf//g;
       $files->{$file} = 1;    
     }
   }
+  closedir(DIR);
   return $files;
 }
 
 sub write_output {
   my $self = shift;
-  $self->dataflow_output_id($self->param('input_for_validation'), 2);
+  $self->dataflow_output_id($self->param('input_for_validation'), 1);
   return;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
@@ -65,8 +65,8 @@ sub default_options {
 
         script_dir         => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/scripts',
 
-        gvf_validator      => 'gvf_validator',
-        so_file            => '/nfs/panda/ensembl/production/ensprod/obo_files/SO.obo',
+        gvf_validator      => '/nfs/users/nfs_a/at7/tools/gvf_validator',
+        so_file            => '/nfs/users/nfs_a/at7/obo/e81/so.obo',
 
         tmp_dir           => $self->o('tmp_dir'),
         gvf_readme => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF',

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PreRunChecks.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PreRunChecks.pm
@@ -36,78 +36,59 @@ use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsPro
 
 use File::Path qw(make_path);
 
+sub fetch_input {
+  my $self = shift;
+}
+
 sub run {
   my $self = shift;
   my $file_type  = $self->param('file_type');	
-  my $species = $self->param('species');
-  my $division = $self->param('division');
-  my $pipeline_dir = $self->param_required('pipeline_dir');
-  my $script_dir = $self->param_required('script_dir');
-  my $tmp_dir = $self->param('tmp_dir');
 
   # check registry file exists
   # check tmp dir exists
 
   if ($file_type eq 'gvf') {
+    foreach my $dir (qw/pipeline_dir script_dir/) {
+      die "$dir doesn't exist" unless (-d $self->param($dir));
+    }
     my $gvf_validator = $self->param('gvf_validator');
     my $so_file = $self->param('so_file');
     die "gvf validator not defined" unless (defined $gvf_validator);
-    my $gvf_validator_error = `which $gvf_validator 2>&1 1>/dev/null`;
-    die "$gvf_validator command not found: $gvf_validator_error" if $gvf_validator_error ne "";
+    die "wrong location for gvf validator" unless (-f $gvf_validator);
     die "so file not defined" unless (defined $so_file);
     die "wrong location for so file" unless (-f $so_file);
   } elsif ($file_type eq 'vcf') {
-    my $vcf_validator = $self->param('vcf_validator');
-    my $vcf_validator_error = `which $vcf_validator 2>&1 1>/dev/null`;
-    die "$vcf_validator command not found: $vcf_validator_error" if $vcf_validator_error ne "";
-    my $vcf_sort = $self->param('vcf_sort');
-    my $vcf_sort_error = `which $vcf_sort 2>&1 1>/dev/null`;
-    die "$vcf_sort command not found: $vcf_sort_error" if $vcf_sort_error ne "";
+    my $location = `which vcf-validator`;
+    die "vcf-validator command not found" if ($location =~ m/Command not found/);				
   } else {
     die "File type: $file_type is not recognised. It must be gvf or vcf.";
   }
 
-  # Create the tmp_dir
-  if (! -d "$tmp_dir") {
-    make_path("$tmp_dir") or die "Failed to create dir $tmp_dir $!";
-  }
-
-  $self->create_species_dir_tree($species,$division,$pipeline_dir,$script_dir, $file_type);
+  $self->create_species_dir_tree();
 }
 
 sub write_output {
   my $self = shift;
-  $self->dataflow_output_id({}, 2);
-  $self->dataflow_output_id({}, 1);
 }
 
 sub create_species_dir_tree {
-  my ($self,$species,$division, $pipeline_dir, $script_dir, $file_type) = @_;
-  my $dump_dir;
+  my $self = shift;
+  my $pipeline_dir = $self->param('pipeline_dir');
+  my $file_type = $self->param('file_type');
+  my $dump_dir = "$pipeline_dir/$file_type/";
+  make_path($dump_dir) unless (-d $dump_dir);	
 
-  if ($division) {
-    my @division = ( ref($division) eq 'ARRAY' ) ? @$division : ($division);
-    # If division is defined.
-    if ( scalar(@division) ) {
-      foreach my $division (@division) {
-        $pipeline_dir=$pipeline_dir."/".$division;
-        $dump_dir = "$pipeline_dir/$file_type/";
-        make_path($dump_dir) unless (-d $dump_dir);
+  my $all_species = $self->get_all_species();
+
+  foreach my $species (keys %$all_species) {
+    if (-d "$dump_dir/$species") {
+      unless (is_empty("$dump_dir/$species")) {
+        die("$dump_dir/$species is not empty. Delete files before running the pipeline.");
       }
-    }
-    else{
-      $dump_dir = "$pipeline_dir/$file_type/";
-      make_path($dump_dir) unless (-d $dump_dir);
-    }
-  }
-
-  if (-d "$dump_dir/$species") {
-    unless (is_empty("$dump_dir/$species")) {
-      die("$dump_dir/$species is not empty. Delete files before running the pipeline.");
-    }
-  } else {
-    make_path("$dump_dir/$species") or die "Failed to create dir $dump_dir/$species $!";
-  }
+    } else {
+      make_path("$dump_dir/$species") or die "Failed to create dir $dump_dir/$species $!";
+    }	
+  }					
 }
 
 sub is_empty {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README
@@ -1,5 +1,6 @@
 Running the pipeline creates GVF and VCF dumps for all species in ensembl with a variation database. The pipeline is run as part of the release cycle.
 
+- 
 - read data from registry file
 - call scripts
 - deal with outputs
@@ -15,19 +16,16 @@ There are two versions ReleaseDumps_conf.pm and PopulationDumps_conf.pm:
     - structural variation
     - sets: phenotype, clin sign
   - To run the pipeline the following parameters need to be initialised:
-    -run_all, division or species, antispecies  Used to know which species the pipeline should process
     -pipeline_dir       directory that store all the data                 
     -pipeline_name      used to create name for hive database
     -hive_db_host       connection details for hive database
     -hive_db_password   connection details for hive database
     -hive_db_port       connection details for hive database
     -hive_db_user       connection details for hive database
-    -registry      registry file with all species for which to create GVF and VCF dumps
+    -registry_file      registry file with all species for which to create GVF and VCF dumps
     -ensembl_release    ensembl release
-    -gvf_validator      location of the gvf_validator tool, e.g: GAL/bin/gvf_validator from github
-    -vcf-validator      location of the vcf-validator tool
-    -vcf-sort           location of the vcf-sort tool
-    -so_file            SO-Ontologies/so.obo e.g. from github.
+    -gvf_validator      GAL/bin/gvf_validator e.g from github
+    -so_file            SO-Ontologies/so.obo e.g. from github
     -tmp_dir            tmp directory for storing validation results, err and out files  
 
 
@@ -39,18 +37,12 @@ There are two versions ReleaseDumps_conf.pm and PopulationDumps_conf.pm:
 
 Dataflow for pipeline 1):
 
-SpeciesFactory
-  - Process value of run_all, division, antispecies or species parameters
-  - For run_all, the speciesFactory will load all the species defined in the registry file and flow back species with existing variation databases
-  - For division, the speciesFactory will process the division using the ensembl_production database and flow back all the variation databases associated with the species in this division
-  - For species, the speciesFactory will process the species, look for it in the registry and flow back the species if it has an existing variation database
-  - For antispecies, the speciesFactory will process a division or all the species from the registry, remove the species from antispecies and flow the variation databases.
-
 PreRunChecks
   - file checks: 
     - checks that registry file exists
-    - checks that directories exist: pipeline_dir script_dir tmp_dir. If not, it will create them.
+    - checks that directories exist: pipeline_dir script_dir tmp_dir
     - checks that GVF validator and SO file exist
+    - checks that vcf-validator is defined
     - creats species directory with species from input registry file
     - checks that species directories for dumping files are empty before starting the pipeline
 
@@ -58,7 +50,7 @@ Config
   - collects all the data types that can be dumped for a species
   - looks up in the database if the species has a certain data type: sift, ancestral allele, global maf, clinical significance, clinical_significance_svs, structural variants
   - the attribs for human are hard coded: we dump more data for human: sets, somatic data 
-  - the data types are stored in the config parameter. This is flow downstream to all the modules.
+  - the data types are stored in json format in a file. the json file is read by subsequent modules.
 
 InitSubmitJob (dump gvf)
   - Prepare all commands for dumping GVF files 
@@ -87,6 +79,7 @@ Validate (gvf)
 
 SummariseValidation (gvf)
   - summarise results in pipeline_dir/SummaryValidateGVF.txt
+  - 
 
 FileUtils (post_gvf_dump_cleanup):
   - for each species:
@@ -96,7 +89,7 @@ FileUtils (post_gvf_dump_cleanup):
  
 
 PreRunChecks (pre_run_checks_gvf2vcf):
-  - checks that vcf-validator and vcf-sort are defined and exists
+  -
 
 InitSubmitJob (parse gvf2vcf):
   - generates all the options for each gvf file that are required by the gvf2vcf script
@@ -105,8 +98,7 @@ SubmitJob (gvf2vcf):
   - for each VCF file create smaller file using the first 2500 lines for validation. use vcf-validator
 
 Validate (vcf):
-  - for each VCF file create smaller file using the first 2500 lines for validation. use VCF validator
-  - Sort and bgzip the VCF files
+
 
 InitJoinDump
   - prepare final join dumps
@@ -127,3 +119,4 @@ Finish:
 
 
 Dataflow for pipeline 2):
+

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/SpeciesFactory.pm
@@ -1,0 +1,64 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=head1 CONTACT
+
+ Please email comments or questions to the public Ensembl
+ developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+ Questions may also be sent to the Ensembl help desk at
+ <http://www.ensembl.org/Help/Contact>.
+
+=cut
+package Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::SpeciesFactory;
+
+use strict;
+use JSON;
+use FileHandle;
+use File::Path qw(make_path);
+
+use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsProcess');
+
+sub run {
+  my $self = shift;
+  my @input;
+  my $config_file = $self->param('config_file');
+  my $fh = FileHandle->new($config_file, 'r');
+  my $config_text = <$fh>;
+  my $config = decode_json($config_text);
+  $fh->close();	
+  foreach my $species (keys %$config) {
+    my $params = {};
+    $params->{species} = $species;
+    $params->{config}  = $config->{$species};
+    push @input, $params;			
+  }
+  $self->param('species', \@input); 
+}
+
+# some dataflow to perform
+sub write_output { 
+  my $self = shift;
+  my $input = $self->param('species');
+  $self->dataflow_output_id($input, 2);
+  return 1;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/SubmitJob.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/SubmitJob.pm
@@ -30,7 +30,10 @@ Questions may also be sent to the Ensembl help desk at
 package Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::SubmitJob;
 
 use strict;
+use FileHandle;
 use base ('Bio::EnsEMBL::Hive::Process');
+
+sub fetch_input {}
 
 sub run {
   my $self = shift;
@@ -56,8 +59,6 @@ sub run {
 
 sub write_output {
   my $self = shift;
-  $self->dataflow_output_id({}, 1);
-  $self->dataflow_output_id({}, 2);
 }
 
 sub run_cmd {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/Validate.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/Validate.pm
@@ -32,6 +32,7 @@ package Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::Validate;
 use strict;
 use base ('Bio::EnsEMBL::Hive::Process');
 use File::Basename;
+sub fetch_input {}
 
 sub run {
   my $self = shift;
@@ -59,15 +60,13 @@ sub validate_gvf {
   my $file = "$working_dir/$file_name.gvf";
   my $file_for_validation = "$working_dir/$file_name\_validate.gvf";
   $self->run_cmd("head -2500 $file > $file_for_validation");
-  my $cmd = "$gvf_validator --so_file $so_file $file_for_validation";
+  my $cmd = "perl $gvf_validator --so_file $so_file $file_for_validation";
   $self->run_cmd("$cmd 1>$out 2>$err");	
   $self->run_cmd("rm $file_for_validation");
 }
 
 sub validate_vcf {
   my $self = shift;
-  my $vcf_validator = $self->param('vcf_validator');
-  my $vcf_sort = $self->param('vcf_sort');
   my $vcf_file = $self->param('vcf_file');
   $vcf_file =~ s/--vcf_file //;
   my ($file_name, $working_dir, $suffix) = fileparse($vcf_file, qr/\.[^.]*/);
@@ -80,13 +79,13 @@ sub validate_vcf {
   $self->run_cmd("head -2500 $vcf_file > $file_for_validation");
 
   # sort and bgzip
-  my $cmd = "$vcf_sort < $vcf_file | bgzip > $vcf_file.gz";
+  my $cmd = "vcf-sort < $vcf_file | bgzip > $vcf_file.gz";
   $self->run_cmd($cmd);
-  $cmd = "$vcf_sort < $file_for_validation | bgzip > $file_for_validation.gz";
+  $cmd = "vcf-sort < $file_for_validation | bgzip > $file_for_validation.gz";
   $self->run_cmd($cmd);
 
   # validate
-  $cmd = "$vcf_validator $file_for_validation.gz";
+  $cmd = "vcf-validator $file_for_validation.gz";
   $self->run_cmd("$cmd 1>$out 2>$err");
   $self->run_cmd("rm $file_for_validation");
 }


### PR DESCRIPTION
The pull request contains the following major changes:

The Ensembl Production Species Factory is now used to retrieve the variation databases from a registry file.
Updated default location for so_file to use the same file that Production use to generate the ontology database.
gvf_validator, vcf_validator and vcf_sort are now part of the ensembl environment.
Restructured the pipeline so that each module can run on one species only.
Deprecated the data_dumps_config.json file and the SpeciesFactory.pm, this data is now passed through the pipeline as a param.
Removed Report.pm as it's not used by any pipeline.
The species division is now stored into the config param, all the modules have been updated to check it's value, if it's empty pipeline_dir will be used. If we have a value for a division, the data will be stored into pipeline_dir and then into a division directory.
Updated checks for vcf, gvf validator to properly report the error if missing, added a check for vcf-sort in PreRunChecks.pm.
Minor tidying up for many modules.
Updated dataflow_output_id to work with new pipeline flows.
Updated README file.

I did a test run on ensembl 89 and EG metazoa 36. Output files are the same as the live version (excluding data recently removed by Anja in 3ec5c9b
Please see:
/hps/nobackup/production/ensembl/maurel/variation_ensembl_test_dumps_89
/hps/nobackup/production/ensembl/maurel/variation_metazoa_test_dumps_36

I will update the confluence documentation as soon as the pull request is merged.